### PR TITLE
Setup Normalize.css with `app.import`

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -21,5 +21,7 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
+  app.import('node_modules/normalize.css/normalize.css');
+
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.16.0",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.2.3",
+    "normalize.css": "8.0.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4622,6 +4622,10 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize.css@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.0.tgz#14ac5e461612538a4ce9be90a7da23f86e718493"
+
 npm-git-info@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/npm-git-info/-/npm-git-info-1.0.3.tgz#a933c42ec321e80d3646e0d6e844afe94630e1d5"


### PR DESCRIPTION
An example of setting up Normalize.css using `app.import`. Normalize.css will be included in `vendor.css`